### PR TITLE
Mention Scibian {8,9} and add links to HPC guides

### DIFF
--- a/content/docs.html
+++ b/content/docs.html
@@ -3,4 +3,17 @@ title: Scibian Documentation
 subtitle: 
 ---
 
- - [Installation]({{ content_url('/docs/installation.html') }})
+## Scibian 9
+
+* **Workstations and servers**: *work in progress*
+* **HPC clusters**:
+ [*Scibian 9 HPC Cluster Installation Guide v0.1*](https://scibian.github.io/scibian-hpc-install-guide/scibian9_hpc_installation_guide-0.1.html)
+ ***(draft)***
+ [[pdf](https://scibian.github.io/scibian-hpc-install-guide/scibian9_hpc_installation_guide-0.1.pdf)]
+
+## Scibian 8
+
+* **Workstations and servers**: [*Scibian 8 Desktop Manual Installation*]({{ content_url('/docs/installation.html') }})
+* **HPC clusters**:
+ [*Scibian 8 HPC Cluster Installation Guide v1.1*](https://scibian.github.io/scibian-hpc-install-guide/scibian8_hpc_installation_guide-1.1.html)
+ [[pdf](https://scibian.github.io/scibian-hpc-install-guide/scibian8_hpc_installation_guide-1.1.pdf)]


### PR DESCRIPTION
This commit separate Scibian 8 and 9 documentations and add links to the HPC Cluster Installation Guides.